### PR TITLE
Fix: standardized config types of wal

### DIFF
--- a/lsm/lsm.go
+++ b/lsm/lsm.go
@@ -178,11 +178,11 @@ func LoadLSM() *LSM {
 		dataLost = true
 	}
 	lsm := &LSM{
-		levels:    make([][]int, MAX_LEVELS),
-		memtables: make([]*memtable.MemTable, 0, MAX_MEMTABLES),
-		wal:       wal,
-		cache:     cache.NewReadPathCache(),
-		DataLost:  dataLost, // Initially assume no data loss
+		levels:     make([][]uint64, MAX_LEVELS),
+		memtables:  make([]*memtable.MemTable, 0, MAX_MEMTABLES),
+		wal:        wal,
+		cache:      cache.NewReadPathCache(),
+		DataLost:   dataLost, // Initially assume no data loss
 		flushPool:  nil,
 		levelLocks: make([]sync.Mutex, int(MAX_LEVELS)),
 	}

--- a/lsm/wal/wal.go
+++ b/lsm/wal/wal.go
@@ -9,27 +9,26 @@ import (
 	block_location "hunddb/model/block_location"
 	record "hunddb/model/record"
 	byte_util "hunddb/utils/byte_util"
-	crc "hunddb/utils/crc"
 	"hunddb/utils/config"
+	crc "hunddb/utils/crc"
 	"math"
 	"os"
 	"regexp"
 	"strconv"
 )
 
-
 // Configuration variables loaded from config file - no hardcoded defaults
 var (
-	BLOCK_SIZE uint16
-	LOG_SIZE   uint16
+	BLOCK_SIZE uint64
+	LOG_SIZE   uint64
 )
 
 // init loads WAL configuration from config file
 func init() {
 	cfg := config.GetConfig()
 	// Always use config - no fallbacks here
-	BLOCK_SIZE = uint16(cfg.BlockManager.BlockSize)
-	LOG_SIZE = uint16(cfg.WAL.LogSize)
+	BLOCK_SIZE = cfg.BlockManager.BlockSize
+	LOG_SIZE = cfg.WAL.LogSize
 }
 
 // WAL represents a Write-Ahead Log implementation for database persistence.
@@ -142,7 +141,7 @@ func (wal *WAL) reloadWAL() error {
 	size := info.Size()
 
 	// How many blocks are written in the last log
-	wal.blocksWrittenInLastLog = uint64(size / BLOCK_SIZE)
+	wal.blocksWrittenInLastLog = uint64(uint64(size) / BLOCK_SIZE)
 
 	f, err = os.Open("hunddb/lsm/wal/metadata.bin")
 	if err != nil {


### PR DESCRIPTION
This pull request refactors the codebase to consistently use `uint64` instead of `int` or `uint16` for block sizes, log sizes, and related calculations in the LSM and WAL modules. This change improves type safety and ensures support for large values, reducing the risk of overflow or truncation errors. The update touches both implementation and test files, standardizing data types and updating all relevant calculations and test cases.

### Type consistency and safety improvements

* Changed the type of `levels` in the `LSM` struct from `[]int` to `[]uint64` in `lsm.go` to match the expected usage of block and log sizes.
* Updated configuration variables `BLOCK_SIZE` and `LOG_SIZE` in `wal.go` from `uint16` to `uint64`, and removed unnecessary type casts when loading from config.
* Refactored all calculations and assignments involving block and log sizes in `wal.go` to use `uint64`, ensuring consistent arithmetic and preventing overflow.

### Test suite updates for type consistency

* Changed all test helpers and test cases in `wal_test.go` to use `uint64` instead of `int` for record sizes, payload sizes, and related calculations, including loop counters and struct fields. [[1]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L19-R21) [[2]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L589-R589) [[3]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L2226-R2226)
* Updated all assertions and calculations in tests to use `uint64`, including conversions of `len()` results and arithmetic involving block and log sizes. [[1]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L631-R631) [[2]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L647-R648) [[3]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1023-R1023) [[4]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1093-R1093) [[5]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1237-R1237) [[6]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1278-R1278) [[7]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1319-R1333) [[8]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1379-R1387)

### Miscellaneous improvements

* Ensured all CRC size and header calculations in both implementation and tests use `uint64` for consistency. [[1]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L502-R508) [[2]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L920-R920) [[3]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L977-R977) [[4]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1104-R1116) [[5]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1168-R1168) [[6]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1181-R1181) [[7]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1190-R1190) [[8]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1212-R1212) [[9]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1247-R1251) [[10]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1288-R1290) [[11]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L1753-R1753) [[12]](diffhunk://#diff-c734e3780d7b60877ae7c3e4468f01cff04a4dddfd7e3c019309a727b8301df3L2104-R2104)

These changes collectively standardize the codebase to use `uint64` for all block and log size-related variables and calculations, improving reliability and maintainability.